### PR TITLE
Set Japanese recognition language

### DIFF
--- a/speech_recognition.py
+++ b/speech_recognition.py
@@ -5,7 +5,8 @@ def recognize_from_microphone():
      # This example requires environment variables named "SPEECH_KEY" and "ENDPOINT"
      # Replace with your own subscription key and endpoint, the endpoint is like : "https://YourServiceRegion.api.cognitive.microsoft.com"
     speech_config = speechsdk.SpeechConfig(subscription=os.environ.get('SPEECH_KEY'), endpoint=os.environ.get('ENDPOINT'))
-    speech_config.speech_recognition_language="en-US"
+    # Set the recognition language to Japanese
+    speech_config.speech_recognition_language="ja-JP"
 
     audio_config = speechsdk.audio.AudioConfig(use_default_microphone=True)
     speech_recognizer = speechsdk.SpeechRecognizer(speech_config=speech_config, audio_config=audio_config)


### PR DESCRIPTION
## Summary
- configure Azure speech SDK to recognize speech in Japanese

## Testing
- `python speech_recognition.py` *(fails: ModuleNotFoundError: No module named 'azure')*

------
https://chatgpt.com/codex/tasks/task_e_685b6590d9a88320bf56ba8b40f0d714